### PR TITLE
Add doctor schedule management feature

### DIFF
--- a/DATABASE FILE/pms_db.sql
+++ b/DATABASE FILE/pms_db.sql
@@ -323,6 +323,25 @@ CREATE TABLE `patients` (
 -- Dumping data for table `patients`
 --
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `doctors`
+--
+
+CREATE TABLE `doctors` (
+  `doctor_id` int(11) NOT NULL,
+  `doctor_code` varchar(20) NOT NULL,
+  `doctor_name` varchar(255) NOT NULL,
+  `doctor_category` varchar(255) DEFAULT NULL,
+  `schedule_day` varchar(50) DEFAULT NULL,
+  `schedule_time` varchar(50) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--
+-- Dumping data for table `doctors`
+--
+
 --
 -- Indexes for dumped tables
 --
@@ -397,6 +416,12 @@ ALTER TABLE `patients`
   ADD PRIMARY KEY (`patient_id`);
 
 --
+-- Indexes for table `doctors`
+--
+ALTER TABLE `doctors`
+  ADD PRIMARY KEY (`doctor_id`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -465,4 +490,10 @@ ALTER TABLE `staff`
 --
 ALTER TABLE `patients`
   MODIFY `patient_id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `doctors`
+--
+ALTER TABLE `doctors`
+  MODIFY `doctor_id` int(11) NOT NULL AUTO_INCREMENT;
 COMMIT;

--- a/application/controllers/Delete.php
+++ b/application/controllers/Delete.php
@@ -96,4 +96,14 @@ class Delete extends CI_Controller
                         $this->load->view('Main/login', $data);
                 }
         }
+
+        public function doctor($id) {
+                if ($this->session->userdata('username') != '') {
+                        $this->CommonModel->delete_info('doctor_id', $id, 'doctors');
+                        redirect('ShowForm/doctor/delete', 'refresh');
+                } else {
+                        $data['wrong_msg'] = "";
+                        $this->load->view('Main/login', $data);
+                }
+        }
 }

--- a/application/controllers/Insert.php
+++ b/application/controllers/Insert.php
@@ -402,4 +402,53 @@ class Insert extends CI_Controller
                         $this->load->view('Main/login', $data);
                 }
         }
+
+        public function create_doctor() {
+                if ($this->session->userdata('username') != '') {
+                        $this->form_validation->set_rules('doctor_name', 'Doctor Name', 'trim|required');
+                        if ($this->form_validation->run() == FALSE) {
+                                redirect('ShowForm/doctor/empty', 'refresh');
+                        } else {
+                                $insert_data = array(
+                                        'doctor_code' => $this->generate_doctor_code(),
+                                        'doctor_name' => $this->input->post('doctor_name'),
+                                        'doctor_category' => $this->input->post('doctor_category'),
+                                        'schedule_day' => $this->input->post('schedule_day'),
+                                        'schedule_time' => $this->input->post('schedule_time')
+                                );
+                                $this->CommonModel->insert_data('doctors', $insert_data);
+                                redirect('ShowForm/doctor/created', 'refresh');
+                        }
+                } else {
+                        $data['wrong_msg'] = "";
+                        $this->load->view('Main/login', $data);
+                }
+        }
+
+        public function edit_doctor($id) {
+                if ($this->session->userdata('username') != '') {
+                        $this->form_validation->set_rules('doctor_name', 'Doctor Name', 'trim|required');
+                        if ($this->form_validation->run() == FALSE) {
+                                redirect('ShowForm/doctor/empty', 'refresh');
+                        } else {
+                                $update_data = array(
+                                        'doctor_name' => $this->input->post('doctor_name'),
+                                        'doctor_category' => $this->input->post('doctor_category'),
+                                        'schedule_day' => $this->input->post('schedule_day'),
+                                        'schedule_time' => $this->input->post('schedule_time')
+                                );
+                                $this->CommonModel->update_data_onerow('doctors', $update_data, 'doctor_id', $id);
+                                redirect('ShowForm/doctor/edited', 'refresh');
+                        }
+                } else {
+                        $data['wrong_msg'] = "";
+                        $this->load->view('Main/login', $data);
+                }
+        }
+
+        private function generate_doctor_code() {
+                $last = $this->db->select_max('doctor_id')->get('doctors')->row();
+                $next = ($last && $last->doctor_id) ? $last->doctor_id + 1 : 1;
+                return 'DR' . str_pad($next, 3, '0', STR_PAD_LEFT);
+        }
 }

--- a/application/controllers/ShowForm.php
+++ b/application/controllers/ShowForm.php
@@ -299,4 +299,40 @@ public function create_medicine_name($msg) {
                 }
         }
 
+        public function doctor($msg)
+        {
+                if ($this->session->userdata('username') != '') {
+                        $data['all_value'] = $this->CommonModel->get_all_info('doctors');
+                        $data['doctor_code'] = $this->generate_doctor_code();
+                        $data['msg'] = $msg;
+                        $this->load->view("header", $data);
+                        $this->load->view("doctor/doctor_info", $data);
+                        $this->load->view("footer");
+                } else {
+                        $data['wrong_msg'] = "";
+                        $this->load->view('Main/login', $data);
+                }
+        }
+
+        public function edit_doctor($id)
+        {
+                if ($this->session->userdata('username') != '') {
+                        $data['one_value'] = $this->CommonModel->get_allinfo_byid('doctors', 'doctor_id', $id);
+                        $data['doctor_code'] = isset($data['one_value'][0]->doctor_code) ? $data['one_value'][0]->doctor_code : '';
+                        $this->load->view("header", $data);
+                        $this->load->view("doctor/edit_doctor", $data);
+                        $this->load->view("footer");
+                } else {
+                        $data['wrong_msg'] = "";
+                        $this->load->view('Main/login', $data);
+                }
+        }
+
+        private function generate_doctor_code()
+        {
+                $last = $this->db->select_max('doctor_id')->get('doctors')->row();
+                $next = ($last && $last->doctor_id) ? $last->doctor_id + 1 : 1;
+                return 'DR' . str_pad($next, 3, '0', STR_PAD_LEFT);
+        }
+
 			}  // end

--- a/application/views/Create_Option/header.php
+++ b/application/views/Create_Option/header.php
@@ -34,7 +34,8 @@
 				<ul class="nav navbar-nav">
 					<li><a href="<?php echo base_url(); ?>Main/enter">Dashboard</a></li>
                     <li><a href="<?php echo base_url(); ?>ShowForm/create_medicine_name/main">Pasien</a>
-					</li>
+                                        </li>
+                    <li><a href="<?php echo base_url(); ?>ShowForm/doctor/main">Queue</a></li>
 					<li><a href="<?php echo base_url(); ?>ShowForm/create_medicine_name/main">Create Options</a>
 					</li>
 					<li><a href="<?php echo base_url(); ?>ShowForm/medicine_purchase_info/main">Inventory</a></li>

--- a/application/views/doctor/doctor_info.php
+++ b/application/views/doctor/doctor_info.php
@@ -1,0 +1,118 @@
+<?php
+if ($msg == "main") {
+    $msg = "";
+} elseif ($msg == "empty") {
+    $msg = "Please fill out all required fields";
+} elseif ($msg == "created") {
+    $msg = "Created Successfully";
+} elseif ($msg == "edit") {
+    $msg = "Edited Successfully";
+} elseif ($msg == "delete") {
+    $msg = "Deleted Successfully";
+}
+?>
+<!-- /.Breadcrumb -->
+<section id="breadcrumb">
+    <div class="container">
+        <ol class="breadcrumb">
+            <li><a href="#">Queue</a></li>
+            <li class="active"><?php echo $msg; ?></li>
+        </ol>
+    </div>
+</section>
+
+<section id="main">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3">
+                <div class="list-group">
+                    <a href="#" class="list-group-item active main-color-bg">
+                        <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> Queue</a>
+                    <a href="<?php echo base_url(); ?>ShowForm/doctor/main" class="list-group-item">
+                        <span class="fa fa-user-md" aria-hidden="true"></span> Doctor</a>
+                </div>
+            </div>
+            <div class="col-md-9">
+                <div class="rounded-0 panel panel-default">
+                    <div class="panel-heading rounded-0 main-color-bg">
+                        <h3 class="panel-title">Add Doctor</h3>
+                    </div>
+                    <div class="panel-body">
+                        <?php echo form_open_multipart('Insert/create_doctor'); ?>
+                        <div class="box-body">
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="doctor_code">Doctor Code</label>
+                                    <input type="text" class="form-control" id="doctor_code" name="doctor_code" value="<?php echo $doctor_code; ?>" readonly>
+                                </div>
+                                <div class="col-sm-6">
+                                    <label for="doctor_name">Doctor Name</label>
+                                    <input type="text" class="form-control" id="doctor_name" name="doctor_name">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="doctor_category">Doctor Category</label>
+                                    <input type="text" class="form-control" id="doctor_category" name="doctor_category">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label for="schedule_day">Schedule</label>
+                                    <input type="text" class="form-control" id="schedule_day" name="schedule_day">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="schedule_time">Schedule Time</label>
+                                    <input type="text" class="form-control" id="schedule_time" name="schedule_time">
+                                </div>
+                                <div class="col-sm-4" style="margin-top: 17px;">
+                                    <button type="submit" class="pull-left btn btn-primary">Create</button>
+                                </div>
+                            </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="rounded-0 panel panel-default">
+                    <div class="panel-heading rounded-0">
+                        <h3 class="panel-title">Doctor List</h3>
+                    </div>
+                    <div class="panel-body">
+                        <table class="table table-striped table-hover table-bordered">
+                            <thead>
+                                <tr>
+                                    <th style="text-align: center;">#</th>
+                                    <th style="text-align: center;">Code</th>
+                                    <th style="text-align: center;">Name</th>
+                                    <th style="text-align: center;">Category</th>
+                                    <th style="text-align: center;">Schedule</th>
+                                    <th style="text-align: center;">Time</th>
+                                    <th style="text-align: center;">Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <?php
+                                $count = 0;
+                                foreach ($all_value as $single_value) {
+                                    $count++; ?>
+                                    <tr>
+                                        <td style="text-align: center;"><?php echo $count; ?></td>
+                                        <td style="text-align: center;"><?php echo $single_value->doctor_code; ?></td>
+                                        <td style="text-align: center;"><?php echo $single_value->doctor_name; ?></td>
+                                        <td style="text-align: center;"><?php echo $single_value->doctor_category; ?></td>
+                                        <td style="text-align: center;"><?php echo $single_value->schedule_day; ?></td>
+                                        <td style="text-align: center;"><?php echo $single_value->schedule_time; ?></td>
+                                        <td style="text-align: center;">
+                                            <a style="margin: 5px;" class="btn btn-danger" href="<?php echo base_url(); ?>Delete/doctor/<?php echo $single_value->doctor_id; ?>">Delete</a>
+                                            <a style="margin: 5px;" class="btn btn-success" href="<?php echo base_url(); ?>ShowForm/edit_doctor/<?php echo $single_value->doctor_id; ?>">Edit</a>
+                                        </td>
+                                    </tr>
+                                <?php } ?>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/application/views/doctor/edit_doctor.php
+++ b/application/views/doctor/edit_doctor.php
@@ -1,0 +1,73 @@
+<?php
+foreach ($one_value as $one_info) {
+    $record_id = $one_info->doctor_id;
+    $doctor_code = $one_info->doctor_code;
+    $doctor_name = $one_info->doctor_name;
+    $doctor_category = $one_info->doctor_category;
+    $schedule_day = $one_info->schedule_day;
+    $schedule_time = $one_info->schedule_time;
+}
+?>
+<section id="breadcrumb">
+    <div class="container">
+        <ol class="breadcrumb">
+            <li><a href="#">Queue</a></li>
+        </ol>
+    </div>
+</section>
+<section id="main">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3">
+                <div class="list-group">
+                    <a href="#" class="list-group-item active main-color-bg">
+                        <span class="glyphicon glyphicon-calendar" aria-hidden="true"></span> Queue</a>
+                    <a href="<?php echo base_url(); ?>ShowForm/doctor/main" class="list-group-item">
+                        <span class="fa fa-user-md" aria-hidden="true"></span> Doctor</a>
+                </div>
+            </div>
+            <div class="col-md-9">
+                <div class="rounded-0 panel panel-default">
+                    <div class="panel-heading rounded-0 main-color-bg">
+                        <h3 class="panel-title">Edit Doctor</h3>
+                    </div>
+                    <div class="panel-body">
+                        <?php echo form_open_multipart('Insert/edit_doctor/' . $record_id); ?>
+                        <div class="box-body">
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="doctor_code">Doctor Code</label>
+                                    <input type="text" class="form-control" id="doctor_code" name="doctor_code" value="<?php echo $doctor_code; ?>" readonly>
+                                </div>
+                                <div class="col-sm-6">
+                                    <label for="doctor_name">Doctor Name</label>
+                                    <input type="text" class="form-control" id="doctor_name" name="doctor_name" value="<?php echo $doctor_name; ?>">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="doctor_category">Doctor Category</label>
+                                    <input type="text" class="form-control" id="doctor_category" name="doctor_category" value="<?php echo $doctor_category; ?>">
+                                </div>
+                                <div class="col-sm-6">
+                                    <label for="schedule_day">Schedule</label>
+                                    <input type="text" class="form-control" id="schedule_day" name="schedule_day" value="<?php echo $schedule_day; ?>">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-6">
+                                    <label for="schedule_time">Schedule Time</label>
+                                    <input type="text" class="form-control" id="schedule_time" name="schedule_time" value="<?php echo $schedule_time; ?>">
+                                </div>
+                                <div class="col-sm-4" style="margin-top: 17px;">
+                                    <button type="submit" class="pull-left btn btn-primary">Update</button>
+                                </div>
+                            </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>

--- a/application/views/header.php
+++ b/application/views/header.php
@@ -38,6 +38,7 @@
                 <ul class="nav navbar-nav">
                     <li><a href="<?php echo base_url(); ?>Main/enter">Dashboard</a></li>
                     <li><a href="<?php echo base_url(); ?>ShowForm/patient/main">Patient</a></li>
+                    <li><a href="<?php echo base_url(); ?>ShowForm/doctor/main">Queue</a></li>
                     <li><a href="<?php echo base_url(); ?>ShowForm/create_medicine_name/main">Buat Opsi</a>
                     </li>
                     <li><a href="<?php echo base_url(); ?>ShowForm/medicine_purchase_info/main">Persediaan</a></li>

--- a/application/views/pasien/header.php
+++ b/application/views/pasien/header.php
@@ -34,7 +34,8 @@
 				<ul class="nav navbar-nav">
 					<li><a href="<?php echo base_url(); ?>Main/enter">Dashboard</a></li>
                     <li><a href="<?php echo base_url(); ?>ShowForm/create_medicine_name/main">Pasien</a>
-					</li>
+                                        </li>
+                    <li><a href="<?php echo base_url(); ?>ShowForm/doctor/main">Queue</a></li>
 					<li><a href="<?php echo base_url(); ?>ShowForm/create_medicine_name/main">Create Options</a>
 					</li>
 					<li><a href="<?php echo base_url(); ?>ShowForm/medicine_purchase_info/main">Inventory</a></li>

--- a/application/views/staff_sales/header.php
+++ b/application/views/staff_sales/header.php
@@ -37,6 +37,7 @@
             <div id="navbar" class="collapse navbar-collapse">
                 <ul class="nav navbar-nav">
                     <li><a href="<?php echo base_url(); ?>ShowForm/patient/main">Patient</a></li>
+                    <li><a href="<?php echo base_url(); ?>ShowForm/doctor/main">Queue</a></li>
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     <li class=""><a href="#">STAFF</a></li>


### PR DESCRIPTION
## Summary
- allow staff to manage doctor schedules
- add queue navigation link
- implement doctor CRUD in controllers
- create views for doctor entry and editing
- update database schema for doctors

## Testing
- `vendor/bin/phpunit --configuration tests/phpunit.xml` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_b_685fe325c8b483219eb5770e011ea60a